### PR TITLE
Correct documentation for `ServerSentEvent`

### DIFF
--- a/server_sent_event.ts
+++ b/server_sent_event.ts
@@ -51,7 +51,7 @@ const DEFAULT_KEEP_ALIVE_INTERVAL = 30_000;
 /** Options which can be set when initializing a {@linkcode ServerSentEvent}. */
 export interface ServerSentEventInit extends EventInit {
   /** Optional arbitrary data to send to the client, data this is a string will
-   * be sent unmodified, otherwise `JSON.parse()` will be used to serialize the
+   * be sent unmodified, otherwise `JSON.stringify` will be used to serialize the
    * value. */
   data?: unknown;
 

--- a/server_sent_event.ts
+++ b/server_sent_event.ts
@@ -50,9 +50,11 @@ const DEFAULT_KEEP_ALIVE_INTERVAL = 30_000;
 
 /** Options which can be set when initializing a {@linkcode ServerSentEvent}. */
 export interface ServerSentEventInit extends EventInit {
-  /** Optional arbitrary data to send to the client, data this is a string will
-   * be sent unmodified, otherwise `JSON.stringify` will be used to serialize the
-   * value. */
+  /**
+   * Optional arbitrary data to send to the client, data this is a string will
+   * be sent unmodified, otherwise `JSON.stringify()` will be used to serialize
+   * the value.
+   */
   data?: unknown;
 
   /** An optional `id` which will be sent with the event and exposed in the


### PR DESCRIPTION
Was incorrectly referring to `JSON.parse` when `JSON.stringify` is actually called. Removes parentheses to be consistent with other usages of `JSON.stringify`